### PR TITLE
added clear command

### DIFF
--- a/src/plugins/clear.js
+++ b/src/plugins/clear.js
@@ -1,0 +1,18 @@
+const clear = {
+  description: "clears the screen (maintains log of current session)",
+  help: [
+    "Usage",
+    "",
+    "clear",
+  ],
+  function() {
+    // Remove lastChild Node from "terminal" DOM until top 5 remain (maintain session metadata)
+    let childrenToRemove = this.terminal.container.childElementCount - 5;
+    while (childrenToRemove != 0) {
+      this.terminal.container.removeChild(this.terminal.container.lastChild);
+      childrenToRemove--;
+    }
+  }
+};
+
+export default clear;


### PR DESCRIPTION
loop over output <pre> nodes backwards to clear terminal. maintains command log (arrow key navigation)

May not be super nice for terminal instances with a lot of child nodes but I couldn't find a way to remove a collection of Nodes without looping.